### PR TITLE
ajaxzip3のURL変更など

### DIFF
--- a/catalog/templates/plugins/catalog/order.html
+++ b/catalog/templates/plugins/catalog/order.html
@@ -358,11 +358,7 @@
 			<p><input type="submit" value="確認画面へ進む" /></p>
 		</fieldset>
 	</form>
-	<!--{if $smarty.server.HTTPS and $smarty.server.HTTPS != 'off'}-->
-	<script type="text/javascript" src="https://ajaxzip3.googlecode.com/svn/trunk/ajaxzip3/ajaxzip3-https.js"></script>
-	<!--{else}-->
-	<script type="text/javascript" src="http://ajaxzip3.googlecode.com/svn/trunk/ajaxzip3/ajaxzip3.js"></script>
-	<!--{/if}-->
+	<script src="https://ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
 	<script type="text/javascript">
 	//初期値の設定
 	var delivery_selected = {$freo.config.plugin.catalog.delivery_selected|default:0};
@@ -385,7 +381,7 @@
 	});
 	$('#calculation').hide();
 
-	$('a[href^=#calculation]').click(function() {
+	$('a[href^="#calculation"]').click(function() {
 		$('#calculation').slideToggle(500);
 
 		return false;

--- a/catalog_order/templates/plugins/catalog_order/admin_order_form.html
+++ b/catalog_order/templates/plugins/catalog_order/admin_order_form.html
@@ -228,11 +228,7 @@
 		</form>
 		<!--{/if}-->
 	</div>
-	<!--{if $smarty.server.HTTPS and $smarty.server.HTTPS != 'off'}-->
-	<script type="text/javascript" src="https://ajaxzip3.googlecode.com/svn/trunk/ajaxzip3/ajaxzip3-https.js"></script>
-	<!--{else}-->
-	<script type="text/javascript" src="http://ajaxzip3.googlecode.com/svn/trunk/ajaxzip3/ajaxzip3.js"></script>
-	<!--{/if}-->
+	<script src="https://ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
 	<script type="text/javascript">
 	{literal}
 	//郵便番号から住所を検索

--- a/catalog_order/templates/plugins/catalog_order/admin_user_form.html
+++ b/catalog_order/templates/plugins/catalog_order/admin_user_form.html
@@ -72,11 +72,7 @@
 			</fieldset>
 		</form>
 		<!--{/if}-->
-		<!--{if $smarty.server.HTTPS and $smarty.server.HTTPS != 'off'}-->
-		<script type="text/javascript" src="https://ajaxzip3.googlecode.com/svn/trunk/ajaxzip3/ajaxzip3-https.js"></script>
-		<!--{else}-->
-		<script type="text/javascript" src="http://ajaxzip3.googlecode.com/svn/trunk/ajaxzip3/ajaxzip3.js"></script>
-		<!--{/if}-->
+		<script src="https://ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
 		<script type="text/javascript">
 		{literal}
 		//郵便番号から住所を検索

--- a/catalog_order/templates/plugins/catalog_order/form.html
+++ b/catalog_order/templates/plugins/catalog_order/form.html
@@ -56,11 +56,7 @@
 			<p><input type="submit" value="登録する" /></p>
 		</fieldset>
 	</form>
-	<!--{if $smarty.server.HTTPS and $smarty.server.HTTPS != 'off'}-->
-	<script type="text/javascript" src="https://ajaxzip3.googlecode.com/svn/trunk/ajaxzip3/ajaxzip3-https.js"></script>
-	<!--{else}-->
-	<script type="text/javascript" src="http://ajaxzip3.googlecode.com/svn/trunk/ajaxzip3/ajaxzip3.js"></script>
-	<!--{/if}-->
+	<script src="https://ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
 	<script type="text/javascript">
 	{literal}
 	//郵便番号から住所を検索


### PR DESCRIPTION
ajaxzip3がGoogle Codeのサービス廃止によりGithubに移行したのに伴い、URLを変更されています（http、httpsも一本化）。
https://github.com/ajaxzip3/ajaxzip3.github.io

公式サイトのフォーム管理プラグインの「郵便番号から住所を自動表示する」の追加コードも同様に変更をお願いします。

あとショッピングカートプラグインの商品ご注文画面で利用可能な配送方法を求めるための計算表が折り畳まないので修正しています。