### PR TITLE
profile拡張プラグインのオプション選択の不具合など

### DIFF
--- a/profile/templates/plugins/profile/admin_form.html
+++ b/profile/templates/plugins/profile/admin_form.html
@@ -176,11 +176,9 @@
 						<!--{elseif $freo.config.plugin.profile.option01_type == 'radio'}-->
 						<dd>
 							<input type="radio" name="plugin_profile[option01]" id="label_option_01" value=""{if !$input.plugin_profile.option01} checked="checked"{/if} /> <label for="label_option_01">選択なし</label>
-							<!--{if $value}-->
 							<!--{foreach from=$freo.config.plugin.profile.option01_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option01]" id="label_option_01_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option01} checked="checked"{/if} /> <label for="label_option_01_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
-							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->
@@ -204,11 +202,9 @@
 						<!--{elseif $freo.config.plugin.profile.option02_type == 'radio'}-->
 						<dd>
 							<input type="radio" name="plugin_profile[option02]" id="label_option_02" value=""{if !$input.plugin_profile.option02} checked="checked"{/if} /> <label for="label_option_02">選択なし</label>
-							<!--{if $value}-->
 							<!--{foreach from=$freo.config.plugin.profile.option02_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option02]" id="label_option_02_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option02} checked="checked"{/if} /> <label for="label_option_02_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
-							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->
@@ -232,11 +228,9 @@
 						<!--{elseif $freo.config.plugin.profile.option03_type == 'radio'}-->
 						<dd>
 							<input type="radio" name="plugin_profile[option03]" id="label_option_03" value=""{if !$input.plugin_profile.option03} checked="checked"{/if} /> <label for="label_option_03">選択なし</label>
-							<!--{if $value}-->
 							<!--{foreach from=$freo.config.plugin.profile.option03_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option03]" id="label_option_03_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option03} checked="checked"{/if} /> <label for="label_option_03_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
-							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->
@@ -260,11 +254,9 @@
 						<!--{elseif $freo.config.plugin.profile.option04_type == 'radio'}-->
 						<dd>
 							<input type="radio" name="plugin_profile[option04]" id="label_option_04" value=""{if !$input.plugin_profile.option04} checked="checked"{/if} /> <label for="label_option_04">選択なし</label>
-							<!--{if $value}-->
 							<!--{foreach from=$freo.config.plugin.profile.option04_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option04]" id="label_option_04_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option04} checked="checked"{/if} /> <label for="label_option_04_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
-							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->
@@ -288,11 +280,9 @@
 						<!--{elseif $freo.config.plugin.profile.option05_type == 'radio'}-->
 						<dd>
 							<input type="radio" name="plugin_profile[option05]" id="label_option_05" value=""{if !$input.plugin_profile.option05} checked="checked"{/if} /> <label for="label_option_05">選択なし</label>
-							<!--{if $value}-->
 							<!--{foreach from=$freo.config.plugin.profile.option05_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option05]" id="label_option_05_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option05} checked="checked"{/if} /> <label for="label_option_05_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
-							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->
@@ -316,11 +306,9 @@
 						<!--{elseif $freo.config.plugin.profile.option06_type == 'radio'}-->
 						<dd>
 							<input type="radio" name="plugin_profile[option06]" id="label_option_06" value=""{if !$input.plugin_profile.option06} checked="checked"{/if} /> <label for="label_option_06">選択なし</label>
-							<!--{if $value}-->
 							<!--{foreach from=$freo.config.plugin.profile.option06_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option06]" id="label_option_06_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option06} checked="checked"{/if} /> <label for="label_option_06_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
-							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->
@@ -344,11 +332,9 @@
 						<!--{elseif $freo.config.plugin.profile.option07_type == 'radio'}-->
 						<dd>
 							<input type="radio" name="plugin_profile[option07]" id="label_option_07" value=""{if !$input.plugin_profile.option07} checked="checked"{/if} /> <label for="label_option_07">選択なし</label>
-							<!--{if $value}-->
 							<!--{foreach from=$freo.config.plugin.profile.option07_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option07]" id="label_option_07_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option07} checked="checked"{/if} /> <label for="label_option_07_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
-							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->
@@ -372,10 +358,8 @@
 						<!--{elseif $freo.config.plugin.profile.option08_type == 'radio'}-->
 						<dd>
 							<input type="radio" name="plugin_profile[option08]" id="label_option_08" value=""{if !$input.plugin_profile.option08} checked="checked"{/if} /> <label for="label_option_08">選択なし</label>
-							<!--{if $value}-->
 							<!--{foreach from=$freo.config.plugin.profile.option08_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option08]" id="label_option_08_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option08} checked="checked"{/if} /> <label for="label_option_08_{$smarty.foreach.loop.index}">{$value}</label>
-							<!--{/if}-->
 							<!--{/foreach}-->
 						</dd>
 						<!--{/if}-->
@@ -400,11 +384,9 @@
 						<!--{elseif $freo.config.plugin.profile.option09_type == 'radio'}-->
 						<dd>
 							<input type="radio" name="plugin_profile[option09]" id="label_option_09" value=""{if !$input.plugin_profile.option09} checked="checked"{/if} /> <label for="label_option_09">選択なし</label>
-							<!--{if $value}-->
 							<!--{foreach from=$freo.config.plugin.profile.option09_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option09]" id="label_option_09_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option09} checked="checked"{/if} /> <label for="label_option_09_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
-							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->
@@ -428,11 +410,9 @@
 						<!--{elseif $freo.config.plugin.profile.option10_type == 'radio'}-->
 						<dd>
 							<input type="radio" name="plugin_profile[option10]" id="label_option_10" value=""{if !$input.plugin_profile.option10} checked="checked"{/if} /> <label for="label_option_10">選択なし</label>
-							<!--{if $value}-->
 							<!--{foreach from=$freo.config.plugin.profile.option10_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option10]" id="label_option_10_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option10} checked="checked"{/if} /> <label for="label_option_10_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
-							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->

--- a/profile/templates/plugins/profile/admin_form.html
+++ b/profile/templates/plugins/profile/admin_form.html
@@ -175,10 +175,12 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option01_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option01]" id="label_option_01" value=""{if !$input.plugin_profile.option01} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option01_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option01]" id="label_option_01" value=""{if !$input.plugin_profile.option01} checked="checked"{/if} /> <label for="label_option_01">選択なし</label>
+							<!--{if $value}-->
+							<!--{foreach from=$freo.config.plugin.profile.option01_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option01]" id="label_option_01_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option01} checked="checked"{/if} /> <label for="label_option_01_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
+							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->
@@ -201,10 +203,12 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option02_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option02]" id="label_option_02" value=""{if !$input.plugin_profile.option02} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option02_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option02]" id="label_option_02" value=""{if !$input.plugin_profile.option02} checked="checked"{/if} /> <label for="label_option_02">選択なし</label>
+							<!--{if $value}-->
+							<!--{foreach from=$freo.config.plugin.profile.option02_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option02]" id="label_option_02_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option02} checked="checked"{/if} /> <label for="label_option_02_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
+							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->
@@ -227,10 +231,12 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option03_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option03]" id="label_option_03" value=""{if !$input.plugin_profile.option03} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option03_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option03]" id="label_option_03" value=""{if !$input.plugin_profile.option03} checked="checked"{/if} /> <label for="label_option_03">選択なし</label>
+							<!--{if $value}-->
+							<!--{foreach from=$freo.config.plugin.profile.option03_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option03]" id="label_option_03_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option03} checked="checked"{/if} /> <label for="label_option_03_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
+							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->
@@ -253,10 +259,12 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option04_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option04]" id="label_option_04" value=""{if !$input.plugin_profile.option04} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option04_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option04]" id="label_option_04" value=""{if !$input.plugin_profile.option04} checked="checked"{/if} /> <label for="label_option_04">選択なし</label>
+							<!--{if $value}-->
+							<!--{foreach from=$freo.config.plugin.profile.option04_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option04]" id="label_option_04_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option04} checked="checked"{/if} /> <label for="label_option_04_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
+							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->
@@ -279,10 +287,12 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option05_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option05]" id="label_option_05" value=""{if !$input.plugin_profile.option05} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option05_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option05]" id="label_option_05" value=""{if !$input.plugin_profile.option05} checked="checked"{/if} /> <label for="label_option_05">選択なし</label>
+							<!--{if $value}-->
+							<!--{foreach from=$freo.config.plugin.profile.option05_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option05]" id="label_option_05_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option05} checked="checked"{/if} /> <label for="label_option_05_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
+							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->
@@ -305,10 +315,12 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option06_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option06]" id="label_option_06" value=""{if !$input.plugin_profile.option06} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option06_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option06]" id="label_option_06" value=""{if !$input.plugin_profile.option06} checked="checked"{/if} /> <label for="label_option_06">選択なし</label>
+							<!--{if $value}-->
+							<!--{foreach from=$freo.config.plugin.profile.option06_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option06]" id="label_option_06_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option06} checked="checked"{/if} /> <label for="label_option_06_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
+							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->
@@ -331,10 +343,12 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option07_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option07]" id="label_option_07" value=""{if !$input.plugin_profile.option07} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option07_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option07]" id="label_option_07" value=""{if !$input.plugin_profile.option07} checked="checked"{/if} /> <label for="label_option_07">選択なし</label>
+							<!--{if $value}-->
+							<!--{foreach from=$freo.config.plugin.profile.option07_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option07]" id="label_option_07_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option07} checked="checked"{/if} /> <label for="label_option_07_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
+							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->
@@ -357,9 +371,11 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option08_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option08]" id="label_option_08" value=""{if !$input.plugin_profile.option08} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option08_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option08]" id="label_option_08" value=""{if !$input.plugin_profile.option08} checked="checked"{/if} /> <label for="label_option_08">選択なし</label>
+							<!--{if $value}-->
+							<!--{foreach from=$freo.config.plugin.profile.option08_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option08]" id="label_option_08_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option08} checked="checked"{/if} /> <label for="label_option_08_{$smarty.foreach.loop.index}">{$value}</label>
+							<!--{/if}-->
 							<!--{/foreach}-->
 						</dd>
 						<!--{/if}-->
@@ -383,10 +399,12 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option09_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option09]" id="label_option_09" value=""{if !$input.plugin_profile.option09} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option09_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option09]" id="label_option_09" value=""{if !$input.plugin_profile.option09} checked="checked"{/if} /> <label for="label_option_09">選択なし</label>
+							<!--{if $value}-->
+							<!--{foreach from=$freo.config.plugin.profile.option09_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option09]" id="label_option_09_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option09} checked="checked"{/if} /> <label for="label_option_09_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
+							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->
@@ -409,10 +427,12 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option10_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option10]" id="label_option_10" value=""{if !$input.plugin_profile.option10} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option10_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option10]" id="label_option_10" value=""{if !$input.plugin_profile.option10} checked="checked"{/if} /> <label for="label_option_10">選択なし</label>
+							<!--{if $value}-->
+							<!--{foreach from=$freo.config.plugin.profile.option10_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option10]" id="label_option_10_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option10} checked="checked"{/if} /> <label for="label_option_10_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
+							<!--{/if}-->
 						</dd>
 						<!--{/if}-->
 					<!--{else}-->

--- a/profile/templates/plugins/profile/form.html
+++ b/profile/templates/plugins/profile/form.html
@@ -178,11 +178,9 @@
 					<!--{elseif $freo.config.plugin.profile.option01_type == 'radio'}-->
 					<dd>
 						<input type="radio" name="plugin_profile[option01]" id="label_option_01" value=""{if !$input.plugin_profile.option01} checked="checked"{/if} /> <label for="label_option_01">選択なし</label>
-						<!--{if $value}-->
 						<!--{foreach from=$freo.config.plugin.profile.option01_text|explode:"\n" item='value' name='loop'}-->
 						<input type="radio" name="plugin_profile[option01]" id="label_option_01_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option01} checked="checked"{/if} /> <label for="label_option_01_{$smarty.foreach.loop.index}">{$value}</label>
 						<!--{/foreach}-->
-						<!--{/if}-->
 					</dd>
 					<!--{/if}-->
 				<!--{else}-->
@@ -206,11 +204,9 @@
 					<!--{elseif $freo.config.plugin.profile.option02_type == 'radio'}-->
 					<dd>
 						<input type="radio" name="plugin_profile[option02]" id="label_option_02" value=""{if !$input.plugin_profile.option02} checked="checked"{/if} /> <label for="label_option_02">選択なし</label>
-						<!--{if $value}-->
 						<!--{foreach from=$freo.config.plugin.profile.option02_text|explode:"\n" item='value' name='loop'}-->
 						<input type="radio" name="plugin_profile[option02]" id="label_option_02_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option02} checked="checked"{/if} /> <label for="label_option_02_{$smarty.foreach.loop.index}">{$value}</label>
 						<!--{/foreach}-->
-						<!--{/if}-->
 					</dd>
 					<!--{/if}-->
 				<!--{else}-->
@@ -234,11 +230,9 @@
 					<!--{elseif $freo.config.plugin.profile.option03_type == 'radio'}-->
 					<dd>
 						<input type="radio" name="plugin_profile[option03]" id="label_option_03" value=""{if !$input.plugin_profile.option03} checked="checked"{/if} /> <label for="label_option_03">選択なし</label>
-						<!--{if $value}-->
 						<!--{foreach from=$freo.config.plugin.profile.option03_text|explode:"\n" item='value' name='loop'}-->
 						<input type="radio" name="plugin_profile[option03]" id="label_option_03_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option03} checked="checked"{/if} /> <label for="label_option_03_{$smarty.foreach.loop.index}">{$value}</label>
 						<!--{/foreach}-->
-						<!--{/if}-->
 					</dd>
 					<!--{/if}-->
 				<!--{else}-->
@@ -262,11 +256,9 @@
 					<!--{elseif $freo.config.plugin.profile.option04_type == 'radio'}-->
 					<dd>
 						<input type="radio" name="plugin_profile[option04]" id="label_option_04" value=""{if !$input.plugin_profile.option04} checked="checked"{/if} /> <label for="label_option_04">選択なし</label>
-						<!--{if $value}-->
 						<!--{foreach from=$freo.config.plugin.profile.option04_text|explode:"\n" item='value' name='loop'}-->
 						<input type="radio" name="plugin_profile[option04]" id="label_option_04_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option04} checked="checked"{/if} /> <label for="label_option_04_{$smarty.foreach.loop.index}">{$value}</label>
 						<!--{/foreach}-->
-						<!--{/if}-->
 					</dd>
 					<!--{/if}-->
 				<!--{else}-->
@@ -290,11 +282,9 @@
 					<!--{elseif $freo.config.plugin.profile.option05_type == 'radio'}-->
 					<dd>
 						<input type="radio" name="plugin_profile[option05]" id="label_option_05" value=""{if !$input.plugin_profile.option05} checked="checked"{/if} /> <label for="label_option_05">選択なし</label>
-						<!--{if $value}-->
 						<!--{foreach from=$freo.config.plugin.profile.option05_text|explode:"\n" item='value' name='loop'}-->
 						<input type="radio" name="plugin_profile[option05]" id="label_option_05_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option05} checked="checked"{/if} /> <label for="label_option_05_{$smarty.foreach.loop.index}">{$value}</label>
 						<!--{/foreach}-->
-						<!--{/if}-->
 					</dd>
 					<!--{/if}-->
 				<!--{else}-->
@@ -318,11 +308,9 @@
 					<!--{elseif $freo.config.plugin.profile.option06_type == 'radio'}-->
 					<dd>
 						<input type="radio" name="plugin_profile[option06]" id="label_option_06" value=""{if !$input.plugin_profile.option06} checked="checked"{/if} /> <label for="label_option_06">選択なし</label>
-						<!--{if $value}-->
 						<!--{foreach from=$freo.config.plugin.profile.option06_text|explode:"\n" item='value' name='loop'}-->
 						<input type="radio" name="plugin_profile[option06]" id="label_option_06_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option06} checked="checked"{/if} /> <label for="label_option_06_{$smarty.foreach.loop.index}">{$value}</label>
 						<!--{/foreach}-->
-						<!--{/if}-->
 					</dd>
 					<!--{/if}-->
 				<!--{else}-->
@@ -346,11 +334,9 @@
 					<!--{elseif $freo.config.plugin.profile.option07_type == 'radio'}-->
 					<dd>
 						<input type="radio" name="plugin_profile[option07]" id="label_option_07" value=""{if !$input.plugin_profile.option07} checked="checked"{/if} /> <label for="label_option_07">選択なし</label>
-						<!--{if $value}-->
 						<!--{foreach from=$freo.config.plugin.profile.option07_text|explode:"\n" item='value' name='loop'}-->
 						<input type="radio" name="plugin_profile[option07]" id="label_option_07_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option07} checked="checked"{/if} /> <label for="label_option_07_{$smarty.foreach.loop.index}">{$value}</label>
 						<!--{/foreach}-->
-						<!--{/if}-->
 					</dd>
 					<!--{/if}-->
 				<!--{else}-->
@@ -374,10 +360,8 @@
 					<!--{elseif $freo.config.plugin.profile.option08_type == 'radio'}-->
 					<dd>
 						<input type="radio" name="plugin_profile[option08]" id="label_option_08" value=""{if !$input.plugin_profile.option08} checked="checked"{/if} /> <label for="label_option_08">選択なし</label>
-						<!--{if $value}-->
 						<!--{foreach from=$freo.config.plugin.profile.option08_text|explode:"\n" item='value' name='loop'}-->
 						<input type="radio" name="plugin_profile[option08]" id="label_option_08_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option08} checked="checked"{/if} /> <label for="label_option_08_{$smarty.foreach.loop.index}">{$value}</label>
-						<!--{/if}-->
 						<!--{/foreach}-->
 					</dd>
 					<!--{/if}-->
@@ -402,11 +386,9 @@
 					<!--{elseif $freo.config.plugin.profile.option09_type == 'radio'}-->
 					<dd>
 						<input type="radio" name="plugin_profile[option09]" id="label_option_09" value=""{if !$input.plugin_profile.option09} checked="checked"{/if} /> <label for="label_option_09">選択なし</label>
-						<!--{if $value}-->
 						<!--{foreach from=$freo.config.plugin.profile.option09_text|explode:"\n" item='value' name='loop'}-->
 						<input type="radio" name="plugin_profile[option09]" id="label_option_09_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option09} checked="checked"{/if} /> <label for="label_option_09_{$smarty.foreach.loop.index}">{$value}</label>
 						<!--{/foreach}-->
-						<!--{/if}-->
 					</dd>
 					<!--{/if}-->
 				<!--{else}-->
@@ -430,11 +412,9 @@
 					<!--{elseif $freo.config.plugin.profile.option10_type == 'radio'}-->
 					<dd>
 						<input type="radio" name="plugin_profile[option10]" id="label_option_10" value=""{if !$input.plugin_profile.option10} checked="checked"{/if} /> <label for="label_option_10">選択なし</label>
-						<!--{if $value}-->
 						<!--{foreach from=$freo.config.plugin.profile.option10_text|explode:"\n" item='value' name='loop'}-->
 						<input type="radio" name="plugin_profile[option10]" id="label_option_10_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option10} checked="checked"{/if} /> <label for="label_option_10_{$smarty.foreach.loop.index}">{$value}</label>
 						<!--{/foreach}-->
-						<!--{/if}-->
 					</dd>
 					<!--{/if}-->
 				<!--{else}-->

--- a/profile/templates/plugins/profile/form.html
+++ b/profile/templates/plugins/profile/form.html
@@ -54,372 +54,392 @@
 							<!--{/foreach}-->
 						</select>
 					</dd>
-				<h3>ファイル</h3>
-				<dl>
-					<!--{if $freo.config.plugin.profile.file01_name}-->
-					<dt>{$freo.config.plugin.profile.file01_name}</dt>
-						<dd>
-							<input type="file" name="plugin_profile[file01]" size="30" />
-							<!--{if $input.plugin_profile.file01}-->
-								<input type="checkbox" name="plugin_profile[file01_remove]" id="label_file01" value="{$input.plugin_profile.file01}"{if $input.plugin_profile.file01_remove} checked="checked"{/if} /> <label for="label_file01">{$input.plugin_profile.file01}を削除</label>
-								<input type="hidden" name="plugin_profile[file01]" value="{$input.plugin_profile.file01}" />
-							<!--{/if}-->
-						</dd>
-					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.file02_name}-->
-					<dt>{$freo.config.plugin.profile.file02_name}</dt>
-						<dd>
-							<input type="file" name="plugin_profile[file02]" size="30" />
-							<!--{if $input.plugin_profile.file02}-->
-								<input type="checkbox" name="plugin_profile[file02_remove]" id="label_file02" value="{$input.plugin_profile.file02}"{if $input.plugin_profile.file02_remove} checked="checked"{/if} /> <label for="label_file02">{$input.plugin_profile.file02}を削除</label>
-								<input type="hidden" name="plugin_profile[file02]" value="{$input.plugin_profile.file02}" />
-							<!--{/if}-->
-						</dd>
-					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.file03_name}-->
-					<dt>{$freo.config.plugin.profile.file03_name}</dt>
-						<dd>
-							<input type="file" name="plugin_profile[file03]" size="30" />
-							<!--{if $input.plugin_profile.file03}-->
-								<input type="checkbox" name="plugin_profile[file03_remove]" id="label_file03" value="{$input.plugin_profile.file03}"{if $input.plugin_profile.file03_remove} checked="checked"{/if} /> <label for="label_file03">{$input.plugin_profile.file03}を削除</label>
-								<input type="hidden" name="plugin_profile[file03]" value="{$input.plugin_profile.file03}" />
-							<!--{/if}-->
-						</dd>
-					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.file04_name}-->
-					<dt>{$freo.config.plugin.profile.file04_name}</dt>
-						<dd>
-							<input type="file" name="plugin_profile[file04]" size="30" />
-							<!--{if $input.plugin_profile.file04}-->
-								<input type="checkbox" name="plugin_profile[file04_remove]" id="label_file04" value="{$input.plugin_profile.file04}"{if $input.plugin_profile.file04_remove} checked="checked"{/if} /> <label for="label_file04">{$input.plugin_profile.file04}を削除</label>
-								<input type="hidden" name="plugin_profile[file04]" value="{$input.plugin_profile.file04}" />
-							<!--{/if}-->
-						</dd>
-					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.file05_name}-->
-					<dt>{$freo.config.plugin.profile.file05_name}</dt>
-						<dd>
-							<input type="file" name="plugin_profile[file05]" size="30" />
-							<!--{if $input.plugin_profile.file05}-->
-								<input type="checkbox" name="plugin_profile[file05_remove]" id="label_file05" value="{$input.plugin_profile.file05}"{if $input.plugin_profile.file05_remove} checked="checked"{/if} /> <label for="label_file05">{$input.plugin_profile.file05}を削除</label>
-								<input type="hidden" name="plugin_profile[file05]" value="{$input.plugin_profile.file05}" />
-							<!--{/if}-->
-						</dd>
-					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.file06_name}-->
-					<dt>{$freo.config.plugin.profile.file06_name}</dt>
-						<dd>
-							<input type="file" name="plugin_profile[file06]" size="30" />
-							<!--{if $input.plugin_profile.file06}-->
-								<input type="checkbox" name="plugin_profile[file06_remove]" id="label_file06" value="{$input.plugin_profile.file06}"{if $input.plugin_profile.file06_remove} checked="checked"{/if} /> <label for="label_file06">{$input.plugin_profile.file06}を削除</label>
-								<input type="hidden" name="plugin_profile[file06]" value="{$input.plugin_profile.file06}" />
-							<!--{/if}-->
-						</dd>
-					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.file07_name}-->
-					<dt>{$freo.config.plugin.profile.file07_name}</dt>
-						<dd>
-							<input type="file" name="plugin_profile[file07]" size="30" />
-							<!--{if $input.plugin_profile.file07}-->
-								<input type="checkbox" name="plugin_profile[file07_remove]" id="label_file07" value="{$input.plugin_profile.file07}"{if $input.plugin_profile.file07_remove} checked="checked"{/if} /> <label for="label_file07">{$input.plugin_profile.file07}を削除</label>
-								<input type="hidden" name="plugin_profile[file07]" value="{$input.plugin_profile.file07}" />
-							<!--{/if}-->
-						</dd>
-					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.file08_name}-->
-					<dt>{$freo.config.plugin.profile.file08_name}</dt>
-						<dd>
-							<input type="file" name="plugin_profile[file08]" size="30" />
-							<!--{if $input.plugin_profile.file08}-->
-								<input type="checkbox" name="plugin_profile[file08_remove]" id="label_file08" value="{$input.plugin_profile.file08}"{if $input.plugin_profile.file08_remove} checked="checked"{/if} /> <label for="label_file08">{$input.plugin_profile.file08}を削除</label>
-								<input type="hidden" name="plugin_profile[file08]" value="{$input.plugin_profile.file08}" />
-							<!--{/if}-->
-						</dd>
-					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.file09_name}-->
-					<dt>{$freo.config.plugin.profile.file09_name}</dt>
-						<dd>
-							<input type="file" name="plugin_profile[file09]" size="30" />
-							<!--{if $input.plugin_profile.file09}-->
-								<input type="checkbox" name="plugin_profile[file09_remove]" id="label_file09" value="{$input.plugin_profile.file09}"{if $input.plugin_profile.file09_remove} checked="checked"{/if} /> <label for="label_file09">{$input.plugin_profile.file09}を削除</label>
-								<input type="hidden" name="plugin_profile[file09]" value="{$input.plugin_profile.file09}" />
-							<!--{/if}-->
-						</dd>
-					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.file10_name}-->
-					<dt>{$freo.config.plugin.profile.file10_name}</dt>
-						<dd>
-							<input type="file" name="plugin_profile[file10]" size="30" />
-							<!--{if $input.plugin_profile.file10}-->
-								<input type="checkbox" name="plugin_profile[file10_remove]" id="label_file10" value="{$input.plugin_profile.file10}"{if $input.plugin_profile.file10_remove} checked="checked"{/if} /> <label for="label_file10">{$input.plugin_profile.file10}を削除</label>
-								<input type="hidden" name="plugin_profile[file10]" value="{$input.plugin_profile.file10}" />
-							<!--{/if}-->
-						</dd>
-					<!--{/if}-->
-				</dl>
-				<h3>オプション</h3>
-				<dl>
-					<!--{if $freo.config.plugin.profile.option01_name}-->
-					<dt>{$freo.config.plugin.profile.option01_name}</dt>
-						<!--{if $freo.config.plugin.profile.option01_type == 'text'}-->
-						<dd><input type="text" name="plugin_profile[option01]" size="50" value="{$input.plugin_profile.option01}" /></dd>
-						<!--{elseif $freo.config.plugin.profile.option01_type == 'textarea'}-->
-						<dd><textarea name="plugin_profile[option01]" cols="50" rows="5">{$input.plugin_profile.option01}</textarea></dd>
-						<!--{elseif $freo.config.plugin.profile.option01_type == 'select'}-->
-						<dd>
-							<select name="plugin_profile[option01]">
-								<option value="">選択してください</option>
-								<!--{foreach from=$freo.config.plugin.profile.option01_text|explode:"\n" item='value'}-->
-								<option value="{$value}"{if $value == $input.plugin_profile.option01} selected="selected"{/if}>{$value}</option>
-								<!--{/foreach}-->
-							</select>
-						</dd>
-						<!--{elseif $freo.config.plugin.profile.option01_type == 'radio'}-->
-						<dd>
-							<input type="radio" name="plugin_profile[option01]" id="label_option_01" value=""{if !$input.plugin_profile.option01} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
+			</dl>
+			<h3>ファイル</h3>
+			<dl>
+				<!--{if $freo.config.plugin.profile.file01_name}-->
+				<dt>{$freo.config.plugin.profile.file01_name}</dt>
+					<dd>
+						<input type="file" name="plugin_profile[file01]" size="30" />
+						<!--{if $input.plugin_profile.file01}-->
+							<input type="checkbox" name="plugin_profile[file01_remove]" id="label_file01" value="{$input.plugin_profile.file01}"{if $input.plugin_profile.file01_remove} checked="checked"{/if} /> <label for="label_file01">{$input.plugin_profile.file01}を削除</label>
+							<input type="hidden" name="plugin_profile[file01]" value="{$input.plugin_profile.file01}" />
+						<!--{/if}-->
+					</dd>
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.file02_name}-->
+				<dt>{$freo.config.plugin.profile.file02_name}</dt>
+					<dd>
+						<input type="file" name="plugin_profile[file02]" size="30" />
+						<!--{if $input.plugin_profile.file02}-->
+							<input type="checkbox" name="plugin_profile[file02_remove]" id="label_file02" value="{$input.plugin_profile.file02}"{if $input.plugin_profile.file02_remove} checked="checked"{/if} /> <label for="label_file02">{$input.plugin_profile.file02}を削除</label>
+							<input type="hidden" name="plugin_profile[file02]" value="{$input.plugin_profile.file02}" />
+						<!--{/if}-->
+					</dd>
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.file03_name}-->
+				<dt>{$freo.config.plugin.profile.file03_name}</dt>
+					<dd>
+						<input type="file" name="plugin_profile[file03]" size="30" />
+						<!--{if $input.plugin_profile.file03}-->
+							<input type="checkbox" name="plugin_profile[file03_remove]" id="label_file03" value="{$input.plugin_profile.file03}"{if $input.plugin_profile.file03_remove} checked="checked"{/if} /> <label for="label_file03">{$input.plugin_profile.file03}を削除</label>
+							<input type="hidden" name="plugin_profile[file03]" value="{$input.plugin_profile.file03}" />
+						<!--{/if}-->
+					</dd>
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.file04_name}-->
+				<dt>{$freo.config.plugin.profile.file04_name}</dt>
+					<dd>
+						<input type="file" name="plugin_profile[file04]" size="30" />
+						<!--{if $input.plugin_profile.file04}-->
+							<input type="checkbox" name="plugin_profile[file04_remove]" id="label_file04" value="{$input.plugin_profile.file04}"{if $input.plugin_profile.file04_remove} checked="checked"{/if} /> <label for="label_file04">{$input.plugin_profile.file04}を削除</label>
+							<input type="hidden" name="plugin_profile[file04]" value="{$input.plugin_profile.file04}" />
+						<!--{/if}-->
+					</dd>
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.file05_name}-->
+				<dt>{$freo.config.plugin.profile.file05_name}</dt>
+					<dd>
+						<input type="file" name="plugin_profile[file05]" size="30" />
+						<!--{if $input.plugin_profile.file05}-->
+							<input type="checkbox" name="plugin_profile[file05_remove]" id="label_file05" value="{$input.plugin_profile.file05}"{if $input.plugin_profile.file05_remove} checked="checked"{/if} /> <label for="label_file05">{$input.plugin_profile.file05}を削除</label>
+							<input type="hidden" name="plugin_profile[file05]" value="{$input.plugin_profile.file05}" />
+						<!--{/if}-->
+					</dd>
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.file06_name}-->
+				<dt>{$freo.config.plugin.profile.file06_name}</dt>
+					<dd>
+						<input type="file" name="plugin_profile[file06]" size="30" />
+						<!--{if $input.plugin_profile.file06}-->
+							<input type="checkbox" name="plugin_profile[file06_remove]" id="label_file06" value="{$input.plugin_profile.file06}"{if $input.plugin_profile.file06_remove} checked="checked"{/if} /> <label for="label_file06">{$input.plugin_profile.file06}を削除</label>
+							<input type="hidden" name="plugin_profile[file06]" value="{$input.plugin_profile.file06}" />
+						<!--{/if}-->
+					</dd>
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.file07_name}-->
+				<dt>{$freo.config.plugin.profile.file07_name}</dt>
+					<dd>
+						<input type="file" name="plugin_profile[file07]" size="30" />
+						<!--{if $input.plugin_profile.file07}-->
+							<input type="checkbox" name="plugin_profile[file07_remove]" id="label_file07" value="{$input.plugin_profile.file07}"{if $input.plugin_profile.file07_remove} checked="checked"{/if} /> <label for="label_file07">{$input.plugin_profile.file07}を削除</label>
+							<input type="hidden" name="plugin_profile[file07]" value="{$input.plugin_profile.file07}" />
+						<!--{/if}-->
+					</dd>
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.file08_name}-->
+				<dt>{$freo.config.plugin.profile.file08_name}</dt>
+					<dd>
+						<input type="file" name="plugin_profile[file08]" size="30" />
+						<!--{if $input.plugin_profile.file08}-->
+							<input type="checkbox" name="plugin_profile[file08_remove]" id="label_file08" value="{$input.plugin_profile.file08}"{if $input.plugin_profile.file08_remove} checked="checked"{/if} /> <label for="label_file08">{$input.plugin_profile.file08}を削除</label>
+							<input type="hidden" name="plugin_profile[file08]" value="{$input.plugin_profile.file08}" />
+						<!--{/if}-->
+					</dd>
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.file09_name}-->
+				<dt>{$freo.config.plugin.profile.file09_name}</dt>
+					<dd>
+						<input type="file" name="plugin_profile[file09]" size="30" />
+						<!--{if $input.plugin_profile.file09}-->
+							<input type="checkbox" name="plugin_profile[file09_remove]" id="label_file09" value="{$input.plugin_profile.file09}"{if $input.plugin_profile.file09_remove} checked="checked"{/if} /> <label for="label_file09">{$input.plugin_profile.file09}を削除</label>
+							<input type="hidden" name="plugin_profile[file09]" value="{$input.plugin_profile.file09}" />
+						<!--{/if}-->
+					</dd>
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.file10_name}-->
+				<dt>{$freo.config.plugin.profile.file10_name}</dt>
+					<dd>
+						<input type="file" name="plugin_profile[file10]" size="30" />
+						<!--{if $input.plugin_profile.file10}-->
+							<input type="checkbox" name="plugin_profile[file10_remove]" id="label_file10" value="{$input.plugin_profile.file10}"{if $input.plugin_profile.file10_remove} checked="checked"{/if} /> <label for="label_file10">{$input.plugin_profile.file10}を削除</label>
+							<input type="hidden" name="plugin_profile[file10]" value="{$input.plugin_profile.file10}" />
+						<!--{/if}-->
+					</dd>
+				<!--{/if}-->
+			</dl>
+			<h3>オプション</h3>
+			<dl>
+				<!--{if $freo.config.plugin.profile.option01_name}-->
+				<dt>{$freo.config.plugin.profile.option01_name}</dt>
+					<!--{if $freo.config.plugin.profile.option01_type == 'text'}-->
+					<dd><input type="text" name="plugin_profile[option01]" size="50" value="{$input.plugin_profile.option01}" /></dd>
+					<!--{elseif $freo.config.plugin.profile.option01_type == 'textarea'}-->
+					<dd><textarea name="plugin_profile[option01]" cols="50" rows="5">{$input.plugin_profile.option01}</textarea></dd>
+					<!--{elseif $freo.config.plugin.profile.option01_type == 'select'}-->
+					<dd>
+						<select name="plugin_profile[option01]">
+							<option value="">選択してください</option>
 							<!--{foreach from=$freo.config.plugin.profile.option01_text|explode:"\n" item='value'}-->
-							<input type="radio" name="plugin_profile[option01]" id="label_option_01_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option01} checked="checked"{/if} /> <label for="label_option_01_{$smarty.foreach.loop.index}">{$value}</label>
+							<option value="{$value}"{if $value == $input.plugin_profile.option01} selected="selected"{/if}>{$value}</option>
 							<!--{/foreach}-->
-						</dd>
+						</select>
+					</dd>
+					<!--{elseif $freo.config.plugin.profile.option01_type == 'radio'}-->
+					<dd>
+						<input type="radio" name="plugin_profile[option01]" id="label_option_01" value=""{if !$input.plugin_profile.option01} checked="checked"{/if} /> <label for="label_option_01">選択なし</label>
+						<!--{if $value}-->
+						<!--{foreach from=$freo.config.plugin.profile.option01_text|explode:"\n" item='value' name='loop'}-->
+						<input type="radio" name="plugin_profile[option01]" id="label_option_01_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option01} checked="checked"{/if} /> <label for="label_option_01_{$smarty.foreach.loop.index}">{$value}</label>
+						<!--{/foreach}-->
 						<!--{/if}-->
-					<!--{else}-->
-					<input type="hidden" name="plugin_profile[option01]" value="" />
+					</dd>
 					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.option02_name}-->
-					<dt>{$freo.config.plugin.profile.option02_name}</dt>
-						<!--{if $freo.config.plugin.profile.option02_type == 'text'}-->
-						<dd><input type="text" name="plugin_profile[option02]" size="50" value="{$input.plugin_profile.option02}" /></dd>
-						<!--{elseif $freo.config.plugin.profile.option02_type == 'textarea'}-->
-						<dd><textarea name="plugin_profile[option02]" cols="50" rows="5">{$input.plugin_profile.option02}</textarea></dd>
-						<!--{elseif $freo.config.plugin.profile.option02_type == 'select'}-->
-						<dd>
-							<select name="plugin_profile[option02]">
-								<option value="">選択してください</option>
-								<!--{foreach from=$freo.config.plugin.profile.option02_text|explode:"\n" item='value'}-->
-								<option value="{$value}"{if $value == $input.plugin_profile.option02} selected="selected"{/if}>{$value}</option>
-								<!--{/foreach}-->
-							</select>
-						</dd>
-						<!--{elseif $freo.config.plugin.profile.option02_type == 'radio'}-->
-						<dd>
-							<input type="radio" name="plugin_profile[option02]" id="label_option_02" value=""{if !$input.plugin_profile.option02} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
+				<!--{else}-->
+				<input type="hidden" name="plugin_profile[option01]" value="" />
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.option02_name}-->
+				<dt>{$freo.config.plugin.profile.option02_name}</dt>
+					<!--{if $freo.config.plugin.profile.option02_type == 'text'}-->
+					<dd><input type="text" name="plugin_profile[option02]" size="50" value="{$input.plugin_profile.option02}" /></dd>
+					<!--{elseif $freo.config.plugin.profile.option02_type == 'textarea'}-->
+					<dd><textarea name="plugin_profile[option02]" cols="50" rows="5">{$input.plugin_profile.option02}</textarea></dd>
+					<!--{elseif $freo.config.plugin.profile.option02_type == 'select'}-->
+					<dd>
+						<select name="plugin_profile[option02]">
+							<option value="">選択してください</option>
 							<!--{foreach from=$freo.config.plugin.profile.option02_text|explode:"\n" item='value'}-->
-							<input type="radio" name="plugin_profile[option02]" id="label_option_02_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option02} checked="checked"{/if} /> <label for="label_option_02_{$smarty.foreach.loop.index}">{$value}</label>
+							<option value="{$value}"{if $value == $input.plugin_profile.option02} selected="selected"{/if}>{$value}</option>
 							<!--{/foreach}-->
-						</dd>
+						</select>
+					</dd>
+					<!--{elseif $freo.config.plugin.profile.option02_type == 'radio'}-->
+					<dd>
+						<input type="radio" name="plugin_profile[option02]" id="label_option_02" value=""{if !$input.plugin_profile.option02} checked="checked"{/if} /> <label for="label_option_02">選択なし</label>
+						<!--{if $value}-->
+						<!--{foreach from=$freo.config.plugin.profile.option02_text|explode:"\n" item='value' name='loop'}-->
+						<input type="radio" name="plugin_profile[option02]" id="label_option_02_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option02} checked="checked"{/if} /> <label for="label_option_02_{$smarty.foreach.loop.index}">{$value}</label>
+						<!--{/foreach}-->
 						<!--{/if}-->
-					<!--{else}-->
-					<input type="hidden" name="plugin_profile[option02]" value="" />
+					</dd>
 					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.option03_name}-->
-					<dt>{$freo.config.plugin.profile.option03_name}</dt>
-						<!--{if $freo.config.plugin.profile.option03_type == 'text'}-->
-						<dd><input type="text" name="plugin_profile[option03]" size="50" value="{$input.plugin_profile.option03}" /></dd>
-						<!--{elseif $freo.config.plugin.profile.option03_type == 'textarea'}-->
-						<dd><textarea name="plugin_profile[option03]" cols="50" rows="5">{$input.plugin_profile.option03}</textarea></dd>
-						<!--{elseif $freo.config.plugin.profile.option03_type == 'select'}-->
-						<dd>
-							<select name="plugin_profile[option03]">
-								<option value="">選択してください</option>
-								<!--{foreach from=$freo.config.plugin.profile.option03_text|explode:"\n" item='value'}-->
-								<option value="{$value}"{if $value == $input.plugin_profile.option03} selected="selected"{/if}>{$value}</option>
-								<!--{/foreach}-->
-							</select>
-						</dd>
-						<!--{elseif $freo.config.plugin.profile.option03_type == 'radio'}-->
-						<dd>
-							<input type="radio" name="plugin_profile[option03]" id="label_option_03" value=""{if !$input.plugin_profile.option03} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
+				<!--{else}-->
+				<input type="hidden" name="plugin_profile[option02]" value="" />
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.option03_name}-->
+				<dt>{$freo.config.plugin.profile.option03_name}</dt>
+					<!--{if $freo.config.plugin.profile.option03_type == 'text'}-->
+					<dd><input type="text" name="plugin_profile[option03]" size="50" value="{$input.plugin_profile.option03}" /></dd>
+					<!--{elseif $freo.config.plugin.profile.option03_type == 'textarea'}-->
+					<dd><textarea name="plugin_profile[option03]" cols="50" rows="5">{$input.plugin_profile.option03}</textarea></dd>
+					<!--{elseif $freo.config.plugin.profile.option03_type == 'select'}-->
+					<dd>
+						<select name="plugin_profile[option03]">
+							<option value="">選択してください</option>
 							<!--{foreach from=$freo.config.plugin.profile.option03_text|explode:"\n" item='value'}-->
-							<input type="radio" name="plugin_profile[option03]" id="label_option_03_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option03} checked="checked"{/if} /> <label for="label_option_03_{$smarty.foreach.loop.index}">{$value}</label>
+							<option value="{$value}"{if $value == $input.plugin_profile.option03} selected="selected"{/if}>{$value}</option>
 							<!--{/foreach}-->
-						</dd>
+						</select>
+					</dd>
+					<!--{elseif $freo.config.plugin.profile.option03_type == 'radio'}-->
+					<dd>
+						<input type="radio" name="plugin_profile[option03]" id="label_option_03" value=""{if !$input.plugin_profile.option03} checked="checked"{/if} /> <label for="label_option_03">選択なし</label>
+						<!--{if $value}-->
+						<!--{foreach from=$freo.config.plugin.profile.option03_text|explode:"\n" item='value' name='loop'}-->
+						<input type="radio" name="plugin_profile[option03]" id="label_option_03_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option03} checked="checked"{/if} /> <label for="label_option_03_{$smarty.foreach.loop.index}">{$value}</label>
+						<!--{/foreach}-->
 						<!--{/if}-->
-					<!--{else}-->
-					<input type="hidden" name="plugin_profile[option03]" value="" />
+					</dd>
 					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.option04_name}-->
-					<dt>{$freo.config.plugin.profile.option04_name}</dt>
-						<!--{if $freo.config.plugin.profile.option04_type == 'text'}-->
-						<dd><input type="text" name="plugin_profile[option04]" size="50" value="{$input.plugin_profile.option04}" /></dd>
-						<!--{elseif $freo.config.plugin.profile.option04_type == 'textarea'}-->
-						<dd><textarea name="plugin_profile[option04]" cols="50" rows="5">{$input.plugin_profile.option04}</textarea></dd>
-						<!--{elseif $freo.config.plugin.profile.option04_type == 'select'}-->
-						<dd>
-							<select name="plugin_profile[option04]">
-								<option value="">選択してください</option>
-								<!--{foreach from=$freo.config.plugin.profile.option04_text|explode:"\n" item='value'}-->
-								<option value="{$value}"{if $value == $input.plugin_profile.option04} selected="selected"{/if}>{$value}</option>
-								<!--{/foreach}-->
-							</select>
-						</dd>
-						<!--{elseif $freo.config.plugin.profile.option04_type == 'radio'}-->
-						<dd>
-							<input type="radio" name="plugin_profile[option04]" id="label_option_04" value=""{if !$input.plugin_profile.option04} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
+				<!--{else}-->
+				<input type="hidden" name="plugin_profile[option03]" value="" />
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.option04_name}-->
+				<dt>{$freo.config.plugin.profile.option04_name}</dt>
+					<!--{if $freo.config.plugin.profile.option04_type == 'text'}-->
+					<dd><input type="text" name="plugin_profile[option04]" size="50" value="{$input.plugin_profile.option04}" /></dd>
+					<!--{elseif $freo.config.plugin.profile.option04_type == 'textarea'}-->
+					<dd><textarea name="plugin_profile[option04]" cols="50" rows="5">{$input.plugin_profile.option04}</textarea></dd>
+					<!--{elseif $freo.config.plugin.profile.option04_type == 'select'}-->
+					<dd>
+						<select name="plugin_profile[option04]">
+							<option value="">選択してください</option>
 							<!--{foreach from=$freo.config.plugin.profile.option04_text|explode:"\n" item='value'}-->
-							<input type="radio" name="plugin_profile[option04]" id="label_option_04_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option04} checked="checked"{/if} /> <label for="label_option_04_{$smarty.foreach.loop.index}">{$value}</label>
+							<option value="{$value}"{if $value == $input.plugin_profile.option04} selected="selected"{/if}>{$value}</option>
 							<!--{/foreach}-->
-						</dd>
+						</select>
+					</dd>
+					<!--{elseif $freo.config.plugin.profile.option04_type == 'radio'}-->
+					<dd>
+						<input type="radio" name="plugin_profile[option04]" id="label_option_04" value=""{if !$input.plugin_profile.option04} checked="checked"{/if} /> <label for="label_option_04">選択なし</label>
+						<!--{if $value}-->
+						<!--{foreach from=$freo.config.plugin.profile.option04_text|explode:"\n" item='value' name='loop'}-->
+						<input type="radio" name="plugin_profile[option04]" id="label_option_04_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option04} checked="checked"{/if} /> <label for="label_option_04_{$smarty.foreach.loop.index}">{$value}</label>
+						<!--{/foreach}-->
 						<!--{/if}-->
-					<!--{else}-->
-					<input type="hidden" name="plugin_profile[option04]" value="" />
+					</dd>
 					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.option05_name}-->
-					<dt>{$freo.config.plugin.profile.option05_name}</dt>
-						<!--{if $freo.config.plugin.profile.option05_type == 'text'}-->
-						<dd><input type="text" name="plugin_profile[option05]" size="50" value="{$input.plugin_profile.option05}" /></dd>
-						<!--{elseif $freo.config.plugin.profile.option05_type == 'textarea'}-->
-						<dd><textarea name="plugin_profile[option05]" cols="50" rows="5">{$input.plugin_profile.option05}</textarea></dd>
-						<!--{elseif $freo.config.plugin.profile.option05_type == 'select'}-->
-						<dd>
-							<select name="plugin_profile[option05]">
-								<option value="">選択してください</option>
-								<!--{foreach from=$freo.config.plugin.profile.option05_text|explode:"\n" item='value'}-->
-								<option value="{$value}"{if $value == $input.plugin_profile.option05} selected="selected"{/if}>{$value}</option>
-								<!--{/foreach}-->
-							</select>
-						</dd>
-						<!--{elseif $freo.config.plugin.profile.option05_type == 'radio'}-->
-						<dd>
-							<input type="radio" name="plugin_profile[option05]" id="label_option_05" value=""{if !$input.plugin_profile.option05} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
+				<!--{else}-->
+				<input type="hidden" name="plugin_profile[option04]" value="" />
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.option05_name}-->
+				<dt>{$freo.config.plugin.profile.option05_name}</dt>
+					<!--{if $freo.config.plugin.profile.option05_type == 'text'}-->
+					<dd><input type="text" name="plugin_profile[option05]" size="50" value="{$input.plugin_profile.option05}" /></dd>
+					<!--{elseif $freo.config.plugin.profile.option05_type == 'textarea'}-->
+					<dd><textarea name="plugin_profile[option05]" cols="50" rows="5">{$input.plugin_profile.option05}</textarea></dd>
+					<!--{elseif $freo.config.plugin.profile.option05_type == 'select'}-->
+					<dd>
+						<select name="plugin_profile[option05]">
+							<option value="">選択してください</option>
 							<!--{foreach from=$freo.config.plugin.profile.option05_text|explode:"\n" item='value'}-->
-							<input type="radio" name="plugin_profile[option05]" id="label_option_05_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option05} checked="checked"{/if} /> <label for="label_option_05_{$smarty.foreach.loop.index}">{$value}</label>
+							<option value="{$value}"{if $value == $input.plugin_profile.option05} selected="selected"{/if}>{$value}</option>
 							<!--{/foreach}-->
-						</dd>
+						</select>
+					</dd>
+					<!--{elseif $freo.config.plugin.profile.option05_type == 'radio'}-->
+					<dd>
+						<input type="radio" name="plugin_profile[option05]" id="label_option_05" value=""{if !$input.plugin_profile.option05} checked="checked"{/if} /> <label for="label_option_05">選択なし</label>
+						<!--{if $value}-->
+						<!--{foreach from=$freo.config.plugin.profile.option05_text|explode:"\n" item='value' name='loop'}-->
+						<input type="radio" name="plugin_profile[option05]" id="label_option_05_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option05} checked="checked"{/if} /> <label for="label_option_05_{$smarty.foreach.loop.index}">{$value}</label>
+						<!--{/foreach}-->
 						<!--{/if}-->
-					<!--{else}-->
-					<input type="hidden" name="plugin_profile[option05]" value="" />
+					</dd>
 					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.option06_name}-->
-					<dt>{$freo.config.plugin.profile.option06_name}</dt>
-						<!--{if $freo.config.plugin.profile.option06_type == 'text'}-->
-						<dd><input type="text" name="plugin_profile[option06]" size="50" value="{$input.plugin_profile.option06}" /></dd>
-						<!--{elseif $freo.config.plugin.profile.option06_type == 'textarea'}-->
-						<dd><textarea name="plugin_profile[option06]" cols="50" rows="5">{$input.plugin_profile.option06}</textarea></dd>
-						<!--{elseif $freo.config.plugin.profile.option06_type == 'select'}-->
-						<dd>
-							<select name="plugin_profile[option06]">
-								<option value="">選択してください</option>
-								<!--{foreach from=$freo.config.plugin.profile.option06_text|explode:"\n" item='value'}-->
-								<option value="{$value}"{if $value == $input.plugin_profile.option06} selected="selected"{/if}>{$value}</option>
-								<!--{/foreach}-->
-							</select>
-						</dd>
-						<!--{elseif $freo.config.plugin.profile.option06_type == 'radio'}-->
-						<dd>
-							<input type="radio" name="plugin_profile[option06]" id="label_option_06" value=""{if !$input.plugin_profile.option06} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
+				<!--{else}-->
+				<input type="hidden" name="plugin_profile[option05]" value="" />
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.option06_name}-->
+				<dt>{$freo.config.plugin.profile.option06_name}</dt>
+					<!--{if $freo.config.plugin.profile.option06_type == 'text'}-->
+					<dd><input type="text" name="plugin_profile[option06]" size="50" value="{$input.plugin_profile.option06}" /></dd>
+					<!--{elseif $freo.config.plugin.profile.option06_type == 'textarea'}-->
+					<dd><textarea name="plugin_profile[option06]" cols="50" rows="5">{$input.plugin_profile.option06}</textarea></dd>
+					<!--{elseif $freo.config.plugin.profile.option06_type == 'select'}-->
+					<dd>
+						<select name="plugin_profile[option06]">
+							<option value="">選択してください</option>
 							<!--{foreach from=$freo.config.plugin.profile.option06_text|explode:"\n" item='value'}-->
-							<input type="radio" name="plugin_profile[option06]" id="label_option_06_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option06} checked="checked"{/if} /> <label for="label_option_06_{$smarty.foreach.loop.index}">{$value}</label>
+							<option value="{$value}"{if $value == $input.plugin_profile.option06} selected="selected"{/if}>{$value}</option>
 							<!--{/foreach}-->
-						</dd>
+						</select>
+					</dd>
+					<!--{elseif $freo.config.plugin.profile.option06_type == 'radio'}-->
+					<dd>
+						<input type="radio" name="plugin_profile[option06]" id="label_option_06" value=""{if !$input.plugin_profile.option06} checked="checked"{/if} /> <label for="label_option_06">選択なし</label>
+						<!--{if $value}-->
+						<!--{foreach from=$freo.config.plugin.profile.option06_text|explode:"\n" item='value' name='loop'}-->
+						<input type="radio" name="plugin_profile[option06]" id="label_option_06_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option06} checked="checked"{/if} /> <label for="label_option_06_{$smarty.foreach.loop.index}">{$value}</label>
+						<!--{/foreach}-->
 						<!--{/if}-->
-					<!--{else}-->
-					<input type="hidden" name="plugin_profile[option06]" value="" />
+					</dd>
 					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.option07_name}-->
-					<dt>{$freo.config.plugin.profile.option07_name}</dt>
-						<!--{if $freo.config.plugin.profile.option07_type == 'text'}-->
-						<dd><input type="text" name="plugin_profile[option07]" size="50" value="{$input.plugin_profile.option07}" /></dd>
-						<!--{elseif $freo.config.plugin.profile.option07_type == 'textarea'}-->
-						<dd><textarea name="plugin_profile[option07]" cols="50" rows="5">{$input.plugin_profile.option07}</textarea></dd>
-						<!--{elseif $freo.config.plugin.profile.option07_type == 'select'}-->
-						<dd>
-							<select name="plugin_profile[option07]">
-								<option value="">選択してください</option>
-								<!--{foreach from=$freo.config.plugin.profile.option07_text|explode:"\n" item='value'}-->
-								<option value="{$value}"{if $value == $input.plugin_profile.option07} selected="selected"{/if}>{$value}</option>
-								<!--{/foreach}-->
-							</select>
-						</dd>
-						<!--{elseif $freo.config.plugin.profile.option07_type == 'radio'}-->
-						<dd>
-							<input type="radio" name="plugin_profile[option07]" id="label_option_07" value=""{if !$input.plugin_profile.option07} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
+				<!--{else}-->
+				<input type="hidden" name="plugin_profile[option06]" value="" />
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.option07_name}-->
+				<dt>{$freo.config.plugin.profile.option07_name}</dt>
+					<!--{if $freo.config.plugin.profile.option07_type == 'text'}-->
+					<dd><input type="text" name="plugin_profile[option07]" size="50" value="{$input.plugin_profile.option07}" /></dd>
+					<!--{elseif $freo.config.plugin.profile.option07_type == 'textarea'}-->
+					<dd><textarea name="plugin_profile[option07]" cols="50" rows="5">{$input.plugin_profile.option07}</textarea></dd>
+					<!--{elseif $freo.config.plugin.profile.option07_type == 'select'}-->
+					<dd>
+						<select name="plugin_profile[option07]">
+							<option value="">選択してください</option>
 							<!--{foreach from=$freo.config.plugin.profile.option07_text|explode:"\n" item='value'}-->
-							<input type="radio" name="plugin_profile[option07]" id="label_option_07_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option07} checked="checked"{/if} /> <label for="label_option_07_{$smarty.foreach.loop.index}">{$value}</label>
+							<option value="{$value}"{if $value == $input.plugin_profile.option07} selected="selected"{/if}>{$value}</option>
 							<!--{/foreach}-->
-						</dd>
+						</select>
+					</dd>
+					<!--{elseif $freo.config.plugin.profile.option07_type == 'radio'}-->
+					<dd>
+						<input type="radio" name="plugin_profile[option07]" id="label_option_07" value=""{if !$input.plugin_profile.option07} checked="checked"{/if} /> <label for="label_option_07">選択なし</label>
+						<!--{if $value}-->
+						<!--{foreach from=$freo.config.plugin.profile.option07_text|explode:"\n" item='value' name='loop'}-->
+						<input type="radio" name="plugin_profile[option07]" id="label_option_07_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option07} checked="checked"{/if} /> <label for="label_option_07_{$smarty.foreach.loop.index}">{$value}</label>
+						<!--{/foreach}-->
 						<!--{/if}-->
-					<!--{else}-->
-					<input type="hidden" name="plugin_profile[option07]" value="" />
+					</dd>
 					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.option08_name}-->
-					<dt>{$freo.config.plugin.profile.option08_name}</dt>
-						<!--{if $freo.config.plugin.profile.option08_type == 'text'}-->
-						<dd><input type="text" name="plugin_profile[option08]" size="50" value="{$input.plugin_profile.option08}" /></dd>
-						<!--{elseif $freo.config.plugin.profile.option08_type == 'textarea'}-->
-						<dd><textarea name="plugin_profile[option08]" cols="50" rows="5">{$input.plugin_profile.option08}</textarea></dd>
-						<!--{elseif $freo.config.plugin.profile.option08_type == 'select'}-->
-						<dd>
-							<select name="plugin_profile[option08]">
-								<option value="">選択してください</option>
-								<!--{foreach from=$freo.config.plugin.profile.option08_text|explode:"\n" item='value'}-->
-								<option value="{$value}"{if $value == $input.plugin_profile.option08} selected="selected"{/if}>{$value}</option>
-								<!--{/foreach}-->
-							</select>
-						</dd>
-						<!--{elseif $freo.config.plugin.profile.option08_type == 'radio'}-->
-						<dd>
-							<input type="radio" name="plugin_profile[option08]" id="label_option_08" value=""{if !$input.plugin_profile.option08} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
+				<!--{else}-->
+				<input type="hidden" name="plugin_profile[option07]" value="" />
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.option08_name}-->
+				<dt>{$freo.config.plugin.profile.option08_name}</dt>
+					<!--{if $freo.config.plugin.profile.option08_type == 'text'}-->
+					<dd><input type="text" name="plugin_profile[option08]" size="50" value="{$input.plugin_profile.option08}" /></dd>
+					<!--{elseif $freo.config.plugin.profile.option08_type == 'textarea'}-->
+					<dd><textarea name="plugin_profile[option08]" cols="50" rows="5">{$input.plugin_profile.option08}</textarea></dd>
+					<!--{elseif $freo.config.plugin.profile.option08_type == 'select'}-->
+					<dd>
+						<select name="plugin_profile[option08]">
+							<option value="">選択してください</option>
 							<!--{foreach from=$freo.config.plugin.profile.option08_text|explode:"\n" item='value'}-->
-							<input type="radio" name="plugin_profile[option08]" id="label_option_08_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option08} checked="checked"{/if} /> <label for="label_option_08_{$smarty.foreach.loop.index}">{$value}</label>
+							<option value="{$value}"{if $value == $input.plugin_profile.option08} selected="selected"{/if}>{$value}</option>
 							<!--{/foreach}-->
-						</dd>
+						</select>
+					</dd>
+					<!--{elseif $freo.config.plugin.profile.option08_type == 'radio'}-->
+					<dd>
+						<input type="radio" name="plugin_profile[option08]" id="label_option_08" value=""{if !$input.plugin_profile.option08} checked="checked"{/if} /> <label for="label_option_08">選択なし</label>
+						<!--{if $value}-->
+						<!--{foreach from=$freo.config.plugin.profile.option08_text|explode:"\n" item='value' name='loop'}-->
+						<input type="radio" name="plugin_profile[option08]" id="label_option_08_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option08} checked="checked"{/if} /> <label for="label_option_08_{$smarty.foreach.loop.index}">{$value}</label>
 						<!--{/if}-->
-					<!--{else}-->
-					<input type="hidden" name="plugin_profile[option08]" value="" />
+						<!--{/foreach}-->
+					</dd>
 					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.option09_name}-->
-					<dt>{$freo.config.plugin.profile.option09_name}</dt>
-						<!--{if $freo.config.plugin.profile.option09_type == 'text'}-->
-						<dd><input type="text" name="plugin_profile[option09]" size="50" value="{$input.plugin_profile.option09}" /></dd>
-						<!--{elseif $freo.config.plugin.profile.option09_type == 'textarea'}-->
-						<dd><textarea name="plugin_profile[option09]" cols="50" rows="5">{$input.plugin_profile.option09}</textarea></dd>
-						<!--{elseif $freo.config.plugin.profile.option09_type == 'select'}-->
-						<dd>
-							<select name="plugin_profile[option09]">
-								<option value="">選択してください</option>
-								<!--{foreach from=$freo.config.plugin.profile.option09_text|explode:"\n" item='value'}-->
-								<option value="{$value}"{if $value == $input.plugin_profile.option09} selected="selected"{/if}>{$value}</option>
-								<!--{/foreach}-->
-							</select>
-						</dd>
-						<!--{elseif $freo.config.plugin.profile.option09_type == 'radio'}-->
-						<dd>
-							<input type="radio" name="plugin_profile[option09]" id="label_option_09" value=""{if !$input.plugin_profile.option09} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
+				<!--{else}-->
+				<input type="hidden" name="plugin_profile[option08]" value="" />
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.option09_name}-->
+				<dt>{$freo.config.plugin.profile.option09_name}</dt>
+					<!--{if $freo.config.plugin.profile.option09_type == 'text'}-->
+					<dd><input type="text" name="plugin_profile[option09]" size="50" value="{$input.plugin_profile.option09}" /></dd>
+					<!--{elseif $freo.config.plugin.profile.option09_type == 'textarea'}-->
+					<dd><textarea name="plugin_profile[option09]" cols="50" rows="5">{$input.plugin_profile.option09}</textarea></dd>
+					<!--{elseif $freo.config.plugin.profile.option09_type == 'select'}-->
+					<dd>
+						<select name="plugin_profile[option09]">
+							<option value="">選択してください</option>
 							<!--{foreach from=$freo.config.plugin.profile.option09_text|explode:"\n" item='value'}-->
-							<input type="radio" name="plugin_profile[option09]" id="label_option_09_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option09} checked="checked"{/if} /> <label for="label_option_09_{$smarty.foreach.loop.index}">{$value}</label>
+							<option value="{$value}"{if $value == $input.plugin_profile.option09} selected="selected"{/if}>{$value}</option>
 							<!--{/foreach}-->
-						</dd>
+						</select>
+					</dd>
+					<!--{elseif $freo.config.plugin.profile.option09_type == 'radio'}-->
+					<dd>
+						<input type="radio" name="plugin_profile[option09]" id="label_option_09" value=""{if !$input.plugin_profile.option09} checked="checked"{/if} /> <label for="label_option_09">選択なし</label>
+						<!--{if $value}-->
+						<!--{foreach from=$freo.config.plugin.profile.option09_text|explode:"\n" item='value' name='loop'}-->
+						<input type="radio" name="plugin_profile[option09]" id="label_option_09_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option09} checked="checked"{/if} /> <label for="label_option_09_{$smarty.foreach.loop.index}">{$value}</label>
+						<!--{/foreach}-->
 						<!--{/if}-->
-					<!--{else}-->
-					<input type="hidden" name="plugin_profile[option09]" value="" />
+					</dd>
 					<!--{/if}-->
-					<!--{if $freo.config.plugin.profile.option10_name}-->
-					<dt>{$freo.config.plugin.profile.option10_name}</dt>
-						<!--{if $freo.config.plugin.profile.option10_type == 'text'}-->
-						<dd><input type="text" name="plugin_profile[option10]" size="50" value="{$input.plugin_profile.option10}" /></dd>
-						<!--{elseif $freo.config.plugin.profile.option10_type == 'textarea'}-->
-						<dd><textarea name="plugin_profile[option10]" cols="50" rows="5">{$input.plugin_profile.option10}</textarea></dd>
-						<!--{elseif $freo.config.plugin.profile.option10_type == 'select'}-->
-						<dd>
-							<select name="plugin_profile[option10]">
-								<option value="">選択してください</option>
-								<!--{foreach from=$freo.config.plugin.profile.option10_text|explode:"\n" item='value'}-->
-								<option value="{$value}"{if $value == $input.plugin_profile.option10} selected="selected"{/if}>{$value}</option>
-								<!--{/foreach}-->
-							</select>
-						</dd>
-						<!--{elseif $freo.config.plugin.profile.option10_type == 'radio'}-->
-						<dd>
-							<input type="radio" name="plugin_profile[option10]" id="label_option_10" value=""{if !$input.plugin_profile.option10} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
+				<!--{else}-->
+				<input type="hidden" name="plugin_profile[option09]" value="" />
+				<!--{/if}-->
+				<!--{if $freo.config.plugin.profile.option10_name}-->
+				<dt>{$freo.config.plugin.profile.option10_name}</dt>
+					<!--{if $freo.config.plugin.profile.option10_type == 'text'}-->
+					<dd><input type="text" name="plugin_profile[option10]" size="50" value="{$input.plugin_profile.option10}" /></dd>
+					<!--{elseif $freo.config.plugin.profile.option10_type == 'textarea'}-->
+					<dd><textarea name="plugin_profile[option10]" cols="50" rows="5">{$input.plugin_profile.option10}</textarea></dd>
+					<!--{elseif $freo.config.plugin.profile.option10_type == 'select'}-->
+					<dd>
+						<select name="plugin_profile[option10]">
+							<option value="">選択してください</option>
 							<!--{foreach from=$freo.config.plugin.profile.option10_text|explode:"\n" item='value'}-->
-							<input type="radio" name="plugin_profile[option10]" id="label_option_10_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option10} checked="checked"{/if} /> <label for="label_option_10_{$smarty.foreach.loop.index}">{$value}</label>
+							<option value="{$value}"{if $value == $input.plugin_profile.option10} selected="selected"{/if}>{$value}</option>
 							<!--{/foreach}-->
-						</dd>
+						</select>
+					</dd>
+					<!--{elseif $freo.config.plugin.profile.option10_type == 'radio'}-->
+					<dd>
+						<input type="radio" name="plugin_profile[option10]" id="label_option_10" value=""{if !$input.plugin_profile.option10} checked="checked"{/if} /> <label for="label_option_10">選択なし</label>
+						<!--{if $value}-->
+						<!--{foreach from=$freo.config.plugin.profile.option10_text|explode:"\n" item='value' name='loop'}-->
+						<input type="radio" name="plugin_profile[option10]" id="label_option_10_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option10} checked="checked"{/if} /> <label for="label_option_10_{$smarty.foreach.loop.index}">{$value}</label>
+						<!--{/foreach}-->
 						<!--{/if}-->
-					<!--{else}-->
-					<input type="hidden" name="plugin_profile[option10]" value="" />
+					</dd>
 					<!--{/if}-->
-				</dl>
+				<!--{else}-->
+				<input type="hidden" name="plugin_profile[option10]" value="" />
+				<!--{/if}-->
 			</dl>
 			<p>
 				<input type="submit" name="preview" value="確認する" />


### PR DESCRIPTION
profile拡張プラグインのオプションのうち、ラジオボタンの「選択なし」のラベルのforの値が"label_option_{$option.id}"となっており、inputのidである"label_option_オプション番号"と不一致なので一致させるなどの修正をしました。

7/19 一部修正して再コミットしました。