### PR TITLE
profile拡張プラグインのオプション選択の修正

### DIFF
--- a/profile/templates/plugins/profile/admin_form.html
+++ b/profile/templates/plugins/profile/admin_form.html
@@ -175,8 +175,8 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option01_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option01]" id="label_option_01" value=""{if !$input.plugin_profile.option01} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option01_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option01]" id="label_option_01" value=""{if !$input.plugin_profile.option01} checked="checked"{/if} /> <label for="label_option_01">選択なし</label>
+							<!--{foreach from=$freo.config.plugin.profile.option01_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option01]" id="label_option_01_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option01} checked="checked"{/if} /> <label for="label_option_01_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
 						</dd>
@@ -201,8 +201,8 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option02_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option02]" id="label_option_02" value=""{if !$input.plugin_profile.option02} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option02_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option02]" id="label_option_02" value=""{if !$input.plugin_profile.option02} checked="checked"{/if} /> <label for="label_option_02">選択なし</label>
+							<!--{foreach from=$freo.config.plugin.profile.option02_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option02]" id="label_option_02_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option02} checked="checked"{/if} /> <label for="label_option_02_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
 						</dd>
@@ -227,8 +227,8 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option03_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option03]" id="label_option_03" value=""{if !$input.plugin_profile.option03} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option03_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option03]" id="label_option_03" value=""{if !$input.plugin_profile.option03} checked="checked"{/if} /> <label for="label_option_03">選択なし</label>
+							<!--{foreach from=$freo.config.plugin.profile.option03_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option03]" id="label_option_03_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option03} checked="checked"{/if} /> <label for="label_option_03_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
 						</dd>
@@ -253,8 +253,8 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option04_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option04]" id="label_option_04" value=""{if !$input.plugin_profile.option04} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option04_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option04]" id="label_option_04" value=""{if !$input.plugin_profile.option04} checked="checked"{/if} /> <label for="label_option_04">選択なし</label>
+							<!--{foreach from=$freo.config.plugin.profile.option04_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option04]" id="label_option_04_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option04} checked="checked"{/if} /> <label for="label_option_04_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
 						</dd>
@@ -279,8 +279,8 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option05_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option05]" id="label_option_05" value=""{if !$input.plugin_profile.option05} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option05_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option05]" id="label_option_05" value=""{if !$input.plugin_profile.option05} checked="checked"{/if} /> <label for="label_option_05">選択なし</label>
+							<!--{foreach from=$freo.config.plugin.profile.option05_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option05]" id="label_option_05_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option05} checked="checked"{/if} /> <label for="label_option_05_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
 						</dd>
@@ -305,8 +305,8 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option06_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option06]" id="label_option_06" value=""{if !$input.plugin_profile.option06} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option06_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option06]" id="label_option_06" value=""{if !$input.plugin_profile.option06} checked="checked"{/if} /> <label for="label_option_06">選択なし</label>
+							<!--{foreach from=$freo.config.plugin.profile.option06_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option06]" id="label_option_06_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option06} checked="checked"{/if} /> <label for="label_option_06_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
 						</dd>
@@ -331,8 +331,8 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option07_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option07]" id="label_option_07" value=""{if !$input.plugin_profile.option07} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option07_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option07]" id="label_option_07" value=""{if !$input.plugin_profile.option07} checked="checked"{/if} /> <label for="label_option_07">選択なし</label>
+							<!--{foreach from=$freo.config.plugin.profile.option07_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option07]" id="label_option_07_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option07} checked="checked"{/if} /> <label for="label_option_07_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
 						</dd>
@@ -357,8 +357,8 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option08_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option08]" id="label_option_08" value=""{if !$input.plugin_profile.option08} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option08_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option08]" id="label_option_08" value=""{if !$input.plugin_profile.option08} checked="checked"{/if} /> <label for="label_option_08">選択なし</label>
+							<!--{foreach from=$freo.config.plugin.profile.option08_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option08]" id="label_option_08_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option08} checked="checked"{/if} /> <label for="label_option_08_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
 						</dd>
@@ -383,8 +383,8 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option09_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option09]" id="label_option_09" value=""{if !$input.plugin_profile.option09} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option09_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option09]" id="label_option_09" value=""{if !$input.plugin_profile.option09} checked="checked"{/if} /> <label for="label_option_09">選択なし</label>
+							<!--{foreach from=$freo.config.plugin.profile.option09_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option09]" id="label_option_09_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option09} checked="checked"{/if} /> <label for="label_option_09_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
 						</dd>
@@ -409,8 +409,8 @@
 						</dd>
 						<!--{elseif $freo.config.plugin.profile.option10_type == 'radio'}-->
 						<dd>
-							<input type="radio" name="plugin_profile[option10]" id="label_option_10" value=""{if !$input.plugin_profile.option10} checked="checked"{/if} /> <label for="label_option_{$option.id}">選択なし</label>
-							<!--{foreach from=$freo.config.plugin.profile.option10_text|explode:"\n" item='value'}-->
+							<input type="radio" name="plugin_profile[option10]" id="label_option_10" value=""{if !$input.plugin_profile.option10} checked="checked"{/if} /> <label for="label_option_10">選択なし</label>
+							<!--{foreach from=$freo.config.plugin.profile.option10_text|explode:"\n" item='value' name='loop'}-->
 							<input type="radio" name="plugin_profile[option10]" id="label_option_10_{$smarty.foreach.loop.index}" value="{$value}"{if $value == $input.plugin_profile.option10} checked="checked"{/if} /> <label for="label_option_10_{$smarty.foreach.loop.index}">{$value}</label>
 							<!--{/foreach}-->
 						</dd>


### PR DESCRIPTION
profile拡張プラグインのオプションのうち、ラジオボタンの「選択なし」のラベルのforの値が"label_option_{$option.id}"となっており、inputのidである"label_option_オプション番号"と不一致なので一致させるなどの修正をしました。